### PR TITLE
Feat: browser data filters basis

### DIFF
--- a/browser/src/main.ts
+++ b/browser/src/main.ts
@@ -14,6 +14,8 @@ import router from "@/router";
 
 import "@/queries";
 
+import "@/modules/filter/styles/main.css";
+
 /** Register Vue */
 const vue = createApp(App);
 const pinia = createPinia();

--- a/browser/src/modules/filter/components/DataFilterBase.vue
+++ b/browser/src/modules/filter/components/DataFilterBase.vue
@@ -1,0 +1,84 @@
+<script setup lang="ts">
+import { useElementHover } from "@vueuse/core";
+import { ref } from "vue";
+
+const props = defineProps<{
+  enabled?: boolean;
+
+  focused?: boolean;
+}>();
+
+const emit = defineEmits<{
+  "update:enabled": [value: boolean];
+}>();
+
+const hoverEl = ref<HTMLDivElement | null>(null);
+const hovered = useElementHover(hoverEl);
+</script>
+
+<template>
+  <div
+    class="d-flex d-data-filter-base"
+    :class="[
+      focused ? 'd-data-filter-base--focused' : undefined,
+      enabled ? 'd-data-filter-base--enabled' : 'd-data-filter-base--disabled',
+      hovered ? 'd-data-filter-base--hovered' : undefined,
+    ]"
+  >
+    <VSheet
+      width="12"
+      class="d-data-base-filter__toggle h-100 rounded-s"
+      :color="enabled ? 'primary' : undefined"
+      style="cursor: pointer"
+      @click="emit('update:enabled', !enabled)"
+    />
+
+    <div ref="hoverEl" class="flex-grow-1">
+      <slot />
+    </div>
+  </div>
+</template>
+
+<style lang="scss">
+@use "vuetify/_settings";
+
+.d-data-base-filter__toggle {
+  cursor: pointer;
+}
+.d-data-filter-base--disabled .d-data-base-filter__toggle {
+  border: rgba(var(--v-theme-primary), 0.38) solid 1px;
+}
+
+// TODO: make use of vuetify's border width and opacity instead of hardcoding
+
+.d-data-filter-base--hovered .d-data-base-filter__toggle {
+  border-color: rgba(var(--v-theme-primary), 1);
+}
+
+.d-data-filter-base--focused .d-data-base-filter__toggle {
+  border-color: rgba(var(--v-theme-primary), 1);
+  border-width: 2px;
+}
+</style>
+<style>
+/*
+ * Remove the border adjacent to the toggle area
+ */
+.v-locale--is-ltr .d-data-filter-base .v-field {
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+}
+
+.v-locale--is-rtl .d-data-filter-base .v-field {
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.v-locale--is-ltr .d-data-base-filter__toggle {
+  border-right-style: none;
+}
+
+.v-locale--is-rtl .d-data-base-filter__toggle {
+  border-left-style: none;
+}
+</style>

--- a/browser/src/modules/filter/composables/dataFilter/index.ts
+++ b/browser/src/modules/filter/composables/dataFilter/index.ts
@@ -452,9 +452,12 @@ function computeDisplayClasses(
     const classes: string[] = [];
 
     for (const key in config) {
+      // @ts-expect-error
+      const value = config[key];
+      const classSuffix = value === 0 ? "" : `-${value}`;
+
       const breakpointClass =
-        // @ts-expect-error
-        key === "xs" ? `v-col-${config[key]}` : `v-col-${key}-${config[key]}`;
+        key === "xs" ? `v-col${classSuffix}` : `v-col-${key}${classSuffix}`;
       classes.push(breakpointClass);
     }
 

--- a/browser/src/modules/filter/composables/dataFilter/index.ts
+++ b/browser/src/modules/filter/composables/dataFilter/index.ts
@@ -1,0 +1,442 @@
+import {
+  defineComponent,
+  h,
+  ref,
+  toValue,
+  type VNode,
+  type MaybeRefOrGetter,
+  type SlotsType,
+  computed,
+  watch,
+  isRef,
+  mergeProps,
+} from "vue";
+
+import { mdiChevronDown } from "@mdi/js";
+import {
+  VRow,
+  VCard,
+  VExpandTransition,
+  VBtn,
+  VIcon,
+  VCardItem,
+  VDefaultsProvider,
+} from "vuetify/components";
+
+import DataFilterBase from "../../components/DataFilterBase.vue";
+
+import { render as renderSelect, type SelectDataFilter } from "./selectFilter";
+export { select } from "./selectFilter";
+import { render as renderText, type TextDataFilter } from "./textFilter";
+export { text } from "./textFilter";
+
+import type { DataFiltersDisplay, DataFilterInjection } from "./types";
+
+/*
+ * Filter Types
+ *
+ * text filter
+ * date
+ * date range
+ * number range
+ * select (single/multiple)
+ * auto complete (single)
+ * auto complete (multiple)
+ * toggle buttons
+ * toggle switch
+ * chip group (single/many)
+ */
+
+type DataFilter = TextDataFilter | SelectDataFilter;
+
+interface UseDataFiltersOptions<TFilter extends Record<string, DataFilter>> {
+  filter: TFilter;
+
+  /**
+   * Whether to collapse the collapsable section of the filters (if it exists)
+   */
+  collapse?: MaybeRefOrGetter<boolean>;
+
+  /**
+   * Default display config, can be overridden at filter-level using filters "display" property
+   */
+  display?: MaybeRefOrGetter<DataFiltersDisplay>;
+}
+
+export default function useDataFilters<
+  TFilter extends Record<string, DataFilter>,
+>(options: UseDataFiltersOptions<TFilter>) {
+  /**
+   * This is required as in fact, surprisingly, typescript adds other valid key types to the mix
+   * even though it is defined as string in `Record<string,...` and symbol does not play well
+   *
+   * @see https://stackoverflow.com/a/72150495/10402951
+   */
+  type FilterName = Extract<keyof TFilter, string>;
+
+  const FilterComponent = defineComponent({
+    slots: Object as SlotsType<{
+      [Property in FilterName as `filter.${Property}`]: {
+        filterName: Property;
+      };
+    }>,
+
+    emits: {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      collapse: (value: boolean) => {
+        return true;
+      },
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      "update:value"(filter: FilterName, ...value: any[]) {
+        return true;
+      },
+
+      "update:enabled"(filter: FilterName, value: boolean) {
+        return true;
+      },
+    },
+
+    setup(props, { slots, emit }) {
+      const collapsableFilters = computed(() =>
+        Object.values(toValue(options.filter)).filter((filter) =>
+          toValue(filter.collapsable),
+        ),
+      );
+
+      /**
+       * Whether there are collapsable filters or not
+       */
+      const collapsable = computed(
+        (): boolean => collapsableFilters.value.length >= 1,
+      );
+
+      const internalCollapsePersis = ref(false);
+      watch(
+        () => toValue(options.collapse),
+        (newValue) => {
+          internalCollapsePersis.value = newValue ?? false;
+        },
+        {
+          immediate: true,
+        },
+      );
+      const internalCollapse = computed({
+        set(value: boolean) {
+          emit("collapse", value);
+          internalCollapsePersis.value = value;
+
+          if (isRef(options.collapse)) {
+            options.collapse.value = value;
+          }
+        },
+        get() {
+          return collapsable.value && internalCollapsePersis.value;
+        },
+      });
+
+      // collapsable filters
+      const collapsableRowClasses = computed(() => {
+        const classList = [];
+        if (!internalCollapse.value) {
+          classList.push("filter-toolbar-expanded");
+        }
+        return classList;
+      });
+
+      // render filters
+      const globalDisplay = toValue(options?.display);
+
+      const filterInjections: {
+        [Property in FilterName]?: DataFilterInjection;
+      } = {};
+
+      watch(
+        () => toValue(options.filter),
+        (filters) => {
+          for (const filterKey in filters) {
+            const filter = filters[filterKey];
+            const focusedRef = ref(false);
+            const hoveredRef = ref(false);
+
+            const internalEnabledPersis = ref(false);
+            watch(
+              () => toValue(filter.enabled),
+              (newValue) => {
+                internalEnabledPersis.value = newValue ?? false;
+              },
+              {
+                immediate: true,
+              },
+            );
+            const internalEnabled = computed({
+              set(value: boolean) {
+                internalEnabledPersis.value = value;
+
+                if (isRef(filter.enabled)) {
+                  filter.enabled = value;
+                }
+              },
+              get() {
+                return internalEnabledPersis.value;
+              },
+            });
+
+            filterInjections[filterKey] = {
+              update(...value: any[]) {
+                internalEnabled.value = true;
+
+                emit("update:value", filterKey, ...value);
+              },
+
+              enabled: internalEnabled,
+              setEnabled(value) {
+                internalEnabled.value = value;
+                emit("update:enabled", filterKey, value);
+              },
+
+              focused: focusedRef,
+              setFocus(value) {
+                focusedRef.value = value ?? true;
+
+                // enable filter on hover
+                if (value) {
+                  internalEnabled.value = true;
+                }
+              },
+
+              hovered: hoveredRef,
+              hoverIn() {
+                hoveredRef.value = true;
+              },
+
+              hoverOut() {
+                hoveredRef.value = true;
+              },
+            };
+          }
+        },
+        { immediate: true, deep: false },
+      );
+
+      function filtersToNodes(filterKeys: FilterName[]) {
+        const filtersRaw: TFilter = options.filter;
+        const filtersRenderMap = {} as unknown as {
+          [key in FilterName]: VNode;
+        };
+        for (const filterKey of filterKeys) {
+          const filterDefinition = filtersRaw[filterKey];
+
+          const baseStaticProps = {
+            class: [
+              computeDisplayClasses(globalDisplay, filterDefinition.display),
+            ],
+
+            [`data-filter-name`]: filterKey,
+          };
+
+          const nodeProps = {
+            class: ["flex-grow-1"],
+          };
+
+          let filterNode: VNode = h("div");
+          const injection = filterInjections[filterKey]!;
+
+          if (filterDefinition.type === "text") {
+            filterNode = renderText(filterDefinition, injection, nodeProps);
+          } else if (filterDefinition.type === "select") {
+            filterNode = renderSelect(filterDefinition, injection, nodeProps);
+          }
+          // render other types of filters
+
+          // Wrap the rendered filter in a DataFilterBase
+          const baseProps = {
+            enabled: injection.enabled.value,
+            "onUpdate:enabled": (newValue: boolean) => {
+              injection.setEnabled(newValue);
+            },
+
+            focused: injection.focused.value,
+          };
+
+          filtersRenderMap[filterKey] = h(
+            DataFilterBase,
+            mergeProps(baseProps, baseStaticProps),
+            () => filterNode,
+          );
+        }
+
+        const filtersVNodes: VNode[] = [];
+
+        for (const filterKey in filtersRenderMap) {
+          const filterSlotFunction = slots?.[`filter.${filterKey}`];
+
+          let renderFn = null;
+          if (filterSlotFunction) {
+            renderFn = h(
+              "div",
+              // @ts-expect-error
+              filterSlotFunction({
+                filterName: filterKey,
+              }),
+            );
+          } else {
+            const filterNode = filtersRenderMap[filterKey];
+            renderFn = filterNode;
+          }
+
+          filtersVNodes.push(renderFn);
+        }
+
+        return filtersVNodes;
+      }
+
+      function renderFilters() {
+        const filtersRaw = toValue(options.filter);
+
+        let nodes: VNode[] = [];
+        if (collapsable.value) {
+          const permanentFilters = Object.entries(filtersRaw)
+            .filter(([key, definition]) => !toValue(definition.collapsable))
+            .map(([key]) => key) as FilterName[];
+          nodes = filtersToNodes(permanentFilters);
+        } else {
+          nodes = filtersToNodes(Object.keys(filtersRaw) as FilterName[]);
+        }
+
+        return h(VCardItem, { class: ["flex-row pa-1"] }, () =>
+          h(VRow, { dense: true, class: ["mx-2 py-1 "] }, () => nodes),
+        );
+      }
+
+      function renderCollapsableFilters() {
+        if (!collapsable.value) {
+          return undefined;
+        }
+
+        const filtersRaw = toValue(options.filter);
+        const collapsableKey = Object.entries(filtersRaw)
+          .filter(([key, definition]) => toValue(definition.collapsable))
+          .map(([key]) => key) as FilterName[];
+
+        return h(VCardItem, { class: "pa-1" }, () => [
+          h(
+            VExpandTransition,
+            // v-show replacement
+            {
+              style: {
+                display: internalCollapse.value ? "none" : undefined,
+              },
+            },
+            () =>
+              h(
+                VRow,
+                {
+                  dense: true,
+                  class: ["mx-2 py-2", collapsableRowClasses.value],
+                },
+                () => filtersToNodes(collapsableKey),
+              ),
+          ),
+        ]);
+      }
+
+      return () => {
+        return h("div", null, [
+          // toolbar
+          h(
+            VCard,
+            {
+              color: "surface",
+              density: "compact",
+              class: "d-flex",
+            },
+            () => [
+              h("h2", { class: "ms-2 pa-2 text-h6" }, "Filter"),
+
+              h(
+                "div",
+                { class: "flex-grow-1" },
+                h(
+                  VDefaultsProvider,
+                  {
+                    defaults: {
+                      global: {
+                        hideDetails: true,
+                        baseColor: "primary",
+                        variant: "outlined",
+                      },
+                    },
+                  },
+                  () => [
+                    renderFilters(),
+
+                    // collapsable filters
+                    renderCollapsableFilters(),
+                  ],
+                ),
+              ),
+
+              // collapse button
+              collapsable.value
+                ? h(
+                    VBtn,
+                    {
+                      icon: true,
+                      variant: "plain",
+                      class: ["me-2 mt-4"],
+                      onClick: () =>
+                        (internalCollapse.value = !internalCollapse.value),
+                    },
+                    () => [
+                      h(VIcon, {
+                        style: {
+                          transform: !internalCollapse.value
+                            ? "rotateX(180deg)"
+                            : "",
+                        },
+                        icon: mdiChevronDown,
+                      }),
+                    ],
+                  )
+                : undefined,
+            ],
+          ),
+        ]);
+      };
+    },
+  });
+
+  return {
+    FilterComponent,
+  };
+}
+
+function computeDisplayClasses(
+  globalConfig?: DataFilter["display"],
+  filterConfig?: DataFilter["display"],
+): string[] {
+  const defaultClasses = ["v-col-12 v-col-md-3"];
+
+  function configToClasses(config: DataFilter["display"]): string[] {
+    const classes: string[] = [];
+
+    for (const key in config) {
+      const breakpointClass =
+        // @ts-expect-error
+        key === "xs" ? `v-col-${config[key]}` : `v-col-${key}-${config[key]}`;
+      classes.push(breakpointClass);
+    }
+
+    return classes;
+  }
+
+  if (filterConfig != null) {
+    return configToClasses(filterConfig);
+  }
+
+  if (globalConfig != null) {
+    return configToClasses(globalConfig);
+  }
+
+  return defaultClasses;
+}

--- a/browser/src/modules/filter/composables/dataFilter/index.ts
+++ b/browser/src/modules/filter/composables/dataFilter/index.ts
@@ -127,7 +127,7 @@ export default function useDataFilters<
         },
 
         hoverOut() {
-          hoveredRef.value = true;
+          hoveredRef.value = false;
         },
       };
     }

--- a/browser/src/modules/filter/composables/dataFilter/index.ts
+++ b/browser/src/modules/filter/composables/dataFilter/index.ts
@@ -56,6 +56,8 @@ type Icon = (typeof VIcon)["$props"]["icon"];
 interface UseDataFiltersOptions<TFilter extends Record<string, DataFilter>> {
   filter: TFilter;
 
+  title?: MaybeRefOrGetter<string>;
+
   collapsableIcon?: MaybeRefOrGetter<Icon>;
   collapsableActiveClass?: MaybeRefOrGetter<any>;
   /**
@@ -386,6 +388,7 @@ export default function useDataFilters<
       }
 
       return () => {
+        const title = toValue(options.title);
         return h("div", null, [
           h(
             VCard,
@@ -398,7 +401,9 @@ export default function useDataFilters<
               // content (title + filters + collapsable area + button)
               h("div", { class: "data-filter__content d-flex" }, [
                 // title
-                h("h2", { class: "ms-2 pa-2 text-h6" }, "Filter"),
+                title
+                  ? h("h2", { class: "ms-2 pa-2 text-h6" }, title)
+                  : undefined,
 
                 // filter bay (in the center)
                 h(

--- a/browser/src/modules/filter/composables/dataFilter/index.ts
+++ b/browser/src/modules/filter/composables/dataFilter/index.ts
@@ -305,10 +305,14 @@ export default function useDataFilters<
               },
             },
             () =>
-              h(VRow, {
-                dense: true,
-                class: ["mx-2 py-2", collapsableRowClasses.value],
-              }),
+              h(
+                VRow,
+                {
+                  dense: true,
+                  class: ["mx-2 py-2", collapsableRowClasses.value],
+                },
+                () => nodes,
+              ),
           ),
         ]);
       }
@@ -380,6 +384,7 @@ export default function useDataFilters<
             {
               color: "surface",
               density: "compact",
+              tag: "section",
             },
             () => [
               // content (title + filters + collapsable area + button)
@@ -390,7 +395,7 @@ export default function useDataFilters<
                 // filter bay (in the center)
                 h(
                   "div",
-                  { class: "flex-grow-1" },
+                  { flat: true, class: "flex-grow-1" },
                   h(
                     VDefaultsProvider,
                     {

--- a/browser/src/modules/filter/composables/dataFilter/index.ts
+++ b/browser/src/modules/filter/composables/dataFilter/index.ts
@@ -81,11 +81,11 @@ export default function useDataFilters<
     } = {};
 
     for (const filterKey in options.filter) {
-      const filter = options.filter[filterKey];
+      const definition = options.filter[filterKey];
       const focusedRef = ref(false);
       const hoveredRef = ref(false);
 
-      const enabled = useProxiedRefOrGetter(filter.enabled, false);
+      const enabled = useProxiedRefOrGetter(definition.enabled, false);
 
       injections[filterKey] = {
         update(...value: any[]) {
@@ -104,8 +104,9 @@ export default function useDataFilters<
         setFocus(value) {
           focusedRef.value = value ?? true;
 
-          // enable filter on hover
-          if (value) {
+          // enable filter on hover (if option is set so)
+          const enableOnFocus = toValue(definition.enableOnFocus) ?? true;
+          if (enableOnFocus && value) {
             enabled.value = true;
           }
         },

--- a/browser/src/modules/filter/composables/dataFilter/selectFilter.ts
+++ b/browser/src/modules/filter/composables/dataFilter/selectFilter.ts
@@ -1,0 +1,95 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import {
+  defineAsyncComponent,
+  h,
+  mergeProps,
+  type VNode,
+  type Ref,
+  type MaybeRefOrGetter,
+  toValue,
+} from "vue";
+import { isRef } from "vue";
+
+import type { VSelect as VSelectType } from "vuetify/components";
+
+import type { DataFilterBase, DataFilterInjection } from "./types";
+
+const VSelect = defineAsyncComponent(
+  async () => (await import("vuetify/components/VSelect")).VSelect,
+);
+
+type ItemType<T> = T extends readonly (infer U)[] ? U : never;
+type Primitive = string | number | boolean | symbol;
+type Val<T, ReturnObject extends boolean> = [T] extends [Primitive]
+  ? T
+  : ReturnObject extends true
+    ? T
+    : any;
+type Value<
+  T,
+  ReturnObject extends boolean,
+  Multiple extends boolean,
+> = Multiple extends true
+  ? readonly Val<T, ReturnObject>[]
+  : Val<T, ReturnObject> | null;
+
+export interface SelectDataFilter<TValue = any> extends DataFilterBase {
+  type: "select";
+
+  props: InstanceType<typeof VSelectType>["$props"];
+
+  value?: MaybeRefOrGetter<TValue>;
+}
+
+type VSelectGenericProps = InstanceType<typeof VSelectType<any>>["$props"];
+
+export function select<
+  T extends readonly any[],
+  ReturnObject extends boolean = false,
+  Multiple extends boolean = false,
+>(
+  config: Omit<SelectDataFilter, "type" | "value" | "props"> & {
+    props?: InstanceType<
+      typeof VSelectType<T, ItemType<T>, ReturnObject, Multiple>
+    >["$props"] &
+      Omit<
+        InstanceType<typeof VSelectType>["$props"],
+        keyof VSelectGenericProps
+      >;
+  } & {
+    value?: MaybeRefOrGetter<Value<ItemType<T>, ReturnObject, Multiple>>;
+  },
+): SelectDataFilter<Value<ItemType<T>, ReturnObject, Multiple>> {
+  // @ts-expect-error
+  return {
+    type: "select",
+    ...config,
+  };
+}
+
+export function render(
+  definition: SelectDataFilter,
+  injection: DataFilterInjection,
+  additionalProps?: Record<string, any>,
+): VNode {
+  const modelProps = {
+    modelValue: toValue(definition.value),
+    "onUpdate:modelValue": (newValue: any) => {
+      if (isRef(definition.value)) {
+        definition.value.value = newValue;
+      }
+      injection.update(newValue);
+    },
+
+    "onUpdate:focused": (value: boolean) => {
+      injection.setFocus(value);
+    },
+  };
+
+  const nodeProps = mergeProps(
+    definition.props ?? {},
+    modelProps,
+    additionalProps ?? {},
+  );
+  return h(VSelect, nodeProps);
+}

--- a/browser/src/modules/filter/composables/dataFilter/textFilter.ts
+++ b/browser/src/modules/filter/composables/dataFilter/textFilter.ts
@@ -1,0 +1,48 @@
+import type { VNode, MaybeRefOrGetter } from "vue";
+import { defineAsyncComponent, h, mergeProps, toValue, isRef } from "vue";
+
+import type { VTextField as VTextFieldType } from "vuetify/components";
+
+import type { DataFilterBase, DataFilterInjection } from "./types";
+
+const VTextField = defineAsyncComponent(
+  async () => (await import("vuetify/components/VTextField")).VTextField,
+);
+
+export interface TextDataFilter extends DataFilterBase {
+  type: "text";
+
+  value?: MaybeRefOrGetter<string>;
+
+  props?: InstanceType<typeof VTextFieldType>["$props"];
+}
+
+export function text(config: Omit<TextDataFilter, "type">): TextDataFilter {
+  return {
+    type: "text",
+    ...config,
+  };
+}
+
+export function render(
+  definition: TextDataFilter,
+  injection: DataFilterInjection,
+  props?: Record<string, any>,
+): VNode {
+  const modelProps = {
+    modelValue: toValue(definition.value),
+    "onUpdate:modelValue": (newValue: string) => {
+      if (isRef(definition.value)) {
+        definition.value.value = newValue;
+      }
+      injection.update(newValue);
+    },
+
+    "onUpdate:focused": (value: boolean) => {
+      injection.setFocus(value);
+    },
+  };
+
+  const nodeProps = mergeProps(definition.props ?? {}, modelProps, props ?? {});
+  return h(VTextField, nodeProps);
+}

--- a/browser/src/modules/filter/composables/dataFilter/types.d.ts
+++ b/browser/src/modules/filter/composables/dataFilter/types.d.ts
@@ -21,6 +21,11 @@ export interface DataFilterBase {
    *
    */
   enabled?: MaybeRefOrGetter<boolean>;
+
+  /**
+   * @default true
+   */
+  enableOnFocus?: MaybeRefOrGetter<boolean>;
 }
 
 export interface DataFilterInjection {
@@ -45,10 +50,4 @@ export interface DataFilterInjection {
   hoverIn(): void;
 
   hoverOut(): void;
-
-  // update value
-  // update enable
-  // disable
-  // update focus
-  // update hover
 }

--- a/browser/src/modules/filter/composables/dataFilter/types.d.ts
+++ b/browser/src/modules/filter/composables/dataFilter/types.d.ts
@@ -1,0 +1,54 @@
+import type { MaybeRefOrGetter } from "vue";
+
+import type { DisplayBreakpoint } from "vuetify";
+
+export type DataFiltersDisplay = Partial<
+  Record<DisplayBreakpoint, number | string>
+>;
+
+export interface DataFilterBase {
+  /**
+   * Per-filter display config. Overrides the global config
+   */
+  display?: DataFiltersDisplay;
+
+  /**
+   *
+   */
+  collapsable?: MaybeRefOrGetter<boolean>;
+
+  /**
+   *
+   */
+  enabled?: MaybeRefOrGetter<boolean>;
+}
+
+export interface DataFilterInjection {
+  /**
+   * Update value
+   */
+  update: (...args: any[]) => void;
+
+  /**
+   *
+   */
+  enabled: Ref<boolean>;
+  setEnabled: (value: boolean) => void;
+
+  focused: Ref<boolean>;
+  setFocus(value?: boolean): void;
+
+  /**
+   *
+   */
+  hovered: Ref<boolean>;
+  hoverIn(): void;
+
+  hoverOut(): void;
+
+  // update value
+  // update enable
+  // disable
+  // update focus
+  // update hover
+}

--- a/browser/src/modules/filter/styles/main.css
+++ b/browser/src/modules/filter/styles/main.css
@@ -1,0 +1,5 @@
+.filter-toolbar-expanded {
+  z-index: 2;
+
+  box-shadow: inset 1px 7px 6px -2px var(--v-shadow-key-umbra-opacity, rgba(0, 0, 0, 0.2));
+}

--- a/browser/src/modules/shared/composables/proxiedRefOrGetter.ts
+++ b/browser/src/modules/shared/composables/proxiedRefOrGetter.ts
@@ -1,0 +1,37 @@
+import { shallowRef, computed, isRef, toValue, watch } from "vue";
+import type { MaybeRefOrGetter } from "vue";
+
+export default function useProxiedRefOrGetter<T>(
+  target: MaybeRefOrGetter<T>,
+  initialValue: T,
+
+  onUpdateCallback?: (value: T) => any,
+) {
+  const persisted = shallowRef<T>();
+  persisted.value = initialValue;
+  watch(
+    () => toValue(target),
+    (newValue) => {
+      persisted.value = newValue;
+    },
+    {
+      immediate: true,
+    },
+  );
+
+  const targetProxy = computed({
+    set(value: T) {
+      persisted.value = value;
+      if (isRef(target)) {
+        target.value = value;
+      }
+
+      onUpdateCallback?.(value);
+    },
+    get() {
+      return persisted.value as T;
+    },
+  });
+
+  return targetProxy;
+}

--- a/browser/src/utils/index.ts
+++ b/browser/src/utils/index.ts
@@ -1,0 +1,3 @@
+export type Merge<A, B> = {
+  [K in keyof A]: K extends keyof B ? B[K] : A[K];
+} & B;


### PR DESCRIPTION
This PR introduces the `filter` module to the `browser` package, with `dataFilter` as the basis for sophisticated upcoming filters. 

### Main features:
* Reusable composable with extensive options. 
*  Everying Vuetify provides is accessible, mixing rather than wrapping
* Access to underlying components, _if required_. (bare-metal access)
* Customizable through custom slots
* Advanced types support and straightforward DX
* Responsive and dynamic sizing of individual filter fields/components.

> **NOTICE**, 
currently only `text` & `select(single/multiple)` are available. The additional filters are easily implemented 

![sections](https://github.com/Esoty-Software-Solutions/dashim/assets/22858957/c25fb677-6ee5-40f0-a1f5-5ce1bc178542)

* **Section 1**
  Permenatant filters (i.e. non-collapsible)
* **Section 2**
  Collapsible filters (opt-in not compulsory). More on this later

* **Section 3**
  Filters `append` slot. Optional could be useful for actions on the filters in general or other possible scenarios 
  
### `enable/disable` toggle

`DataFilterBase` functions as a generic wrapper of data filter fields. A filter as per spec is enabled upon user interaction. `enableOnFocus` is available and of course upon value changes.

### Sizing 
 
Inspired by Vuetiyf's responsive approach, the filters are fully responsive as shown below
![sizing](https://github.com/Esoty-Software-Solutions/dashim/assets/22858957/5dc5e5cf-b1b3-4134-908e-ef51a9adc404)

### Collapsible filters badge

The "expand" button will highlight if a collapsed filter is enabled. In addition to that, the icon can be customized, custom styling for each state of the button is customizable.


![non enabled](https://github.com/Esoty-Software-Solutions/dashim/assets/22858957/085dbdd9-56c7-4851-9f4b-c080304c4066)
![enabled badge](https://github.com/Esoty-Software-Solutions/dashim/assets/22858957/8fd0d6c2-ab5f-49fe-9d08-c9b5a81c29db)

... More to come