### PR TITLE
refactor: `querierTable` composable refactored to handle new response…

### DIFF
--- a/browser/src/modules/shared/composables/useQuerierTable.ts
+++ b/browser/src/modules/shared/composables/useQuerierTable.ts
@@ -19,16 +19,11 @@ type IInputBase = {
   [x: string]: any;
 };
 
-interface MetadataBase {
-  unFilteredCount: number;
-  [key: string]: any;
-}
-
 interface IOutputBase {
   data: Record<string, any>[];
   filteredCount: number;
-  metaData: MetadataBase;
-  statistics: { key: string; value: any }[];
+  unFilteredCount: number;
+  statistics: { key: string; value: string | number | boolean }[];
 }
 
 type FindCallback<TInput extends IInputBase, TOutput extends IOutputBase> = (


### PR DESCRIPTION
This PR refactors `querierTable` composable to cope with the new changes (removed `metaData`, added other fields)