### PR TITLE
fix: handle `void` input type in `querierTable` composable

### DIFF
--- a/browser/src/modules/institution/stores/storeList.ts
+++ b/browser/src/modules/institution/stores/storeList.ts
@@ -3,7 +3,11 @@ import { defineStore } from "pinia";
 import { ref } from "vue";
 
 import useQuerierTable from "@/modules/shared/composables/useQuerierTable";
-import { client } from "@/queries";
+import { client, type RouterInput } from "@/queries";
+
+// See the input later
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type FindManyInput = RouterInput["crud"]["institution"]["findMany"];
 
 const useStoreList = defineStore("institutionsStoreList", () => {
   const nameFilter = useLocalStorage("institutionsList.nameFilterValue", "");
@@ -13,7 +17,25 @@ const useStoreList = defineStore("institutionsStoreList", () => {
   );
 
   const { binding, items } = useQuerierTable({
+    /*
+     * There are multiple ways to pass your input as this is a `MayBeRefOrGetter`
+     * _might want to learn more about this at_
+     *
+     * Input Argument conventions of vue composables
+     * https://vuejs.org/guide/reusability/composables#input-arguments
+     * 
+
+     * If you are going with the getter approach like below
+     * keep in mind that the return of the getter only benefits from
+     * type inference this is how TypeScript is
+     * 
+     * See Contextual Typing
+     * https://www.typescriptlang.org/docs/handbook/type-inference.html#contextual-typing
+     *
+     */
     input: () => {
+      // you may want to use this if you want to access the types ahead of time.
+      /* const where: FindManyInput['where'] = {} */
       const where: any = {};
 
       if (nameFilterEnabled.value && nameFilter.value.trim()) {
@@ -21,6 +43,8 @@ const useStoreList = defineStore("institutionsStoreList", () => {
       }
 
       return {
+        // only here type inference is available
+        // this has nothing to do with our code
         where,
       };
     },

--- a/browser/src/modules/shared/composables/useQuerierTable.ts
+++ b/browser/src/modules/shared/composables/useQuerierTable.ts
@@ -11,13 +11,15 @@ import type { ProcedureOptions } from "@trpc/server";
 
 export type UseQuerierTableReturn = ReturnType<typeof useQuerierTable>;
 
-type IInputBase = {
+interface IInputBase {
   skip?: number;
   take?: number;
   orderBy?: any;
   where?: any;
   [x: string]: any;
-};
+}
+
+type TInputBase = IInputBase | undefined | void;
 
 interface IOutputBase {
   data: Record<string, any>[];
@@ -26,20 +28,20 @@ interface IOutputBase {
   statistics: { key: string; value: string | number | boolean }[];
 }
 
-type FindCallback<TInput extends IInputBase, TOutput extends IOutputBase> = (
+type FindCallback<TInput extends TInputBase, TOutput extends IOutputBase> = (
   input: TInput,
   opts?: ProcedureOptions,
 ) => Promise<TOutput | null | undefined>;
 
 export interface UseQuerierOptions<
-  TInput extends IInputBase,
+  TInput extends TInputBase,
   TOutputRaw extends IOutputBase = IOutputBase,
 > {
   storageKey: string;
   /**
    * Filtering options except pagination related
    */
-  input: MaybeRefOrGetter<Omit<TInput, "take" | "skip">>;
+  input: MaybeRefOrGetter<Omit<Exclude<TInput, void>, "take" | "skip">>;
   /**
    * Whether to trigger fetch upon initialization
    * @default false
@@ -62,7 +64,7 @@ export interface UseQuerierOptions<
 }
 
 function useQuerierTable<
-  TInput extends IInputBase,
+  TInput extends TInputBase,
   TOutputRaw extends IOutputBase = IOutputBase,
 >(options: UseQuerierOptions<TInput, TOutputRaw>) {
   const items = ref([]) as Ref<TOutputRaw["data"]>;

--- a/browser/src/queries/index.ts
+++ b/browser/src/queries/index.ts
@@ -1,7 +1,9 @@
 import { createTRPCProxyClient } from "@trpc/client";
 import { httpBatchLink } from "@trpc/client/links/httpBatchLink";
 
+import type { inferRouterInputs, inferRouterOutputs } from "@trpc/server";
 import type { AppRouter } from "dashim_server/src/routers/_.router";
+export type { AppRouter } from "dashim_server/src/routers/_.router";
 
 /// <reference types="../../../server/node_modules/.prisma/client" />
 
@@ -11,3 +13,6 @@ const url = import.meta.env.VITE_FULL_TRPC_URL;
 export const client = createTRPCProxyClient<AppRouter>({
   links: [httpBatchLink({ url })],
 });
+
+export type RouterOutput = inferRouterOutputs<AppRouter>;
+export type RouterInput = inferRouterInputs<AppRouter>;


### PR DESCRIPTION
Update `querierTable` composable to handle the addition of type `void` to the input parameter type of tRPC procedures. This allows for enhanced type support for browser client DX

![image](https://github.com/Esoty-Software-Solutions/dashim/assets/22858957/6ebfb6fa-9d6c-4717-a6f8-dd64c1333b96)
