### PR TITLE
chore: bump vuetify to 3.5.x

### DIFF
--- a/browser/package.json
+++ b/browser/package.json
@@ -29,13 +29,13 @@
     "vue-i18n": "^9.9.0",
     "vue-query": "^1.26.0",
     "vue-router": "^4.2.5",
-    "vuetify": "^3.4.9",
+    "vuetify": "^3.5.2",
     "webfontloader": "^1.6.28"
   },
   "devDependencies": {
     "@mdi/js": "^7.2.96",
     "@rushstack/eslint-patch": "^1.3.3",
-"@trpc/server": "^10.45.0",
+    "@trpc/server": "^10.45.0",
     "@tsconfig/node-lts": "^18.12.5",
     "@types/debounce": "^1.2.4",
     "@types/jsdom": "^21.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "vue-i18n": "^9.9.0",
         "vue-query": "^1.26.0",
         "vue-router": "^4.2.5",
-        "vuetify": "^3.4.9",
+        "vuetify": "^3.5.2",
         "webfontloader": "^1.6.28"
       },
       "devDependencies": {
@@ -1252,7 +1252,6 @@
       "version": "5.8.0",
       "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.8.0.tgz",
       "integrity": "sha512-QxO6C4MaA/ysTIbC+EcAH1aX/YkpymhXtO6zPdk+FvA7+59tNibIYpd+7koPdViLg2iKES4ojsxWNUGNJaEcbA==",
-      "dev": true,
       "hasInstallScript": true,
       "engines": {
         "node": ">=16.13"
@@ -14358,9 +14357,9 @@
       }
     },
     "node_modules/vuetify": {
-      "version": "3.4.9",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.4.9.tgz",
-      "integrity": "sha512-pgBPdbgrHHHZWRybWevzRFezMax6CP2MccTivjOZSOF0XsnzoNOJGGpkTgIfBrk4UCp9jKx6JOJIztGtx/IcSw==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.5.2.tgz",
+      "integrity": "sha512-H/g9+8Loykt50qe9mruHkwWsAIgfQ8gO+SPTAV2uaCFmfYPSFRfu0aGcZ42iWu4bZ9ZkgswIIDaVsfnKINd8yg==",
       "engines": {
         "node": "^12.20 || >=14.13"
       },
@@ -15008,31 +15007,14 @@
         "node": ">=12"
       }
     },
-    "server/node_modules/@prisma/client": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.7.1.tgz",
-      "integrity": "sha512-TUSa4nUcC4nf/e7X3jyO1pEd6XcI/TLRCA0KjkA46RDIpxUaRsBYEOqITwXRW2c0bMFyKcCRXrH4f7h4q9oOlg==",
-      "hasInstallScript": true,
-      "engines": {
-        "node": ">=16.13"
-      },
-      "peerDependencies": {
-        "prisma": "*"
-      },
-      "peerDependenciesMeta": {
-        "prisma": {
-          "optional": true
-        }
-      }
-    },
     "server/node_modules/@prisma/debug": {
       "version": "5.7.1",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0"
     },
     "server/node_modules/@prisma/engines": {
       "version": "5.7.1",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -15044,12 +15026,12 @@
     },
     "server/node_modules/@prisma/engines-version": {
       "version": "5.7.1-1.0ca5ccbcfa6bdc81c003cf549abe4269f59c41e5",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0"
     },
     "server/node_modules/@prisma/fetch-engine": {
       "version": "5.7.1",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "5.7.1",
@@ -15067,7 +15049,7 @@
     },
     "server/node_modules/@prisma/get-platform": {
       "version": "5.7.1",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "5.7.1"
@@ -16284,20 +16266,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "server/node_modules/emphasize/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "server/node_modules/emphasize/node_modules/chalk": {
       "version": "4.1.2",
       "dev": true,
@@ -16312,22 +16280,6 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
-    },
-    "server/node_modules/emphasize/node_modules/color-convert": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "server/node_modules/emphasize/node_modules/color-name": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT"
     },
     "server/node_modules/emphasize/node_modules/has-flag": {
       "version": "4.0.0",
@@ -17748,20 +17700,6 @@
         "node": ">=14"
       }
     },
-    "server/node_modules/pretty-repl/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "server/node_modules/pretty-repl/node_modules/chalk": {
       "version": "4.1.2",
       "dev": true,
@@ -17776,22 +17714,6 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
-    },
-    "server/node_modules/pretty-repl/node_modules/color-convert": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "server/node_modules/pretty-repl/node_modules/color-name": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT"
     },
     "server/node_modules/pretty-repl/node_modules/has-flag": {
       "version": "4.0.0",
@@ -17814,7 +17736,7 @@
     },
     "server/node_modules/prisma": {
       "version": "5.7.1",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -18240,36 +18162,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "server/node_modules/slice-ansi/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "server/node_modules/slice-ansi/node_modules/color-convert": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "server/node_modules/slice-ansi/node_modules/color-name": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT"
     },
     "server/node_modules/snake-case": {
       "version": "3.0.4",
@@ -18818,36 +18710,6 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "server/node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "server/node_modules/wrap-ansi/node_modules/color-convert": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "server/node_modules/wrap-ansi/node_modules/color-name": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT"
-    },
     "server/node_modules/ws": {
       "version": "8.13.0",
       "dev": true,
@@ -19018,74 +18880,6 @@
       },
       "peerDependencies": {
         "zod": "^3.18.0"
-      }
-    },
-    "spa": {
-      "name": "spa-client",
-      "extraneous": true,
-      "dependencies": {
-        "@trpc/client": "^10.6.0",
-        "@vueuse/core": "^10.7.1",
-        "abort-controller": "^3.0.0",
-        "debounce": "^1.2.1",
-        "lodash": "^4.17.21",
-        "vue": "^3.4.1",
-        "vue-query": "^1.26.0",
-        "vue-router": "^4.2.5",
-        "vuetify": "^3.4.9",
-        "webfontloader": "^1.6.28"
-      },
-      "devDependencies": {
-        "@mdi/js": "^7.2.96",
-        "@rushstack/eslint-patch": "^1.3.3",
-        "@tsconfig/node-lts": "^18.12.5",
-        "@types/debounce": "^1.2.4",
-        "@types/jsdom": "^21.1.2",
-        "@types/lodash": "^4.14.202",
-        "@types/node": "^20.5.7",
-        "@types/webfontloader": "^1.6.35",
-        "@typescript-eslint/parser": "^6.6.0",
-        "@vitejs/plugin-vue": "^5.0.0",
-        "@vitest/coverage-c8": "^0.33.0",
-        "@vue/eslint-config-prettier": "^8.0.0",
-        "@vue/eslint-config-typescript": "^11.0.3",
-        "@vue/test-utils": "^2.4.1",
-        "@vue/tsconfig": "^0.4.0",
-        "autoprefixer": "^10.4.13",
-        "dashim_server": "file:../server",
-        "eslint": "^8.48.0",
-        "eslint-config-prettier": "^9.0.0",
-        "eslint-import-resolver-alias": "^1.1.2",
-        "eslint-import-resolver-typescript": "^3.6.0",
-        "eslint-plugin-import": "^2.28.1",
-        "eslint-plugin-n": "^16.0.2",
-        "eslint-plugin-prettier": "^5.0.0",
-        "eslint-plugin-promise": "^6.1.1",
-        "eslint-plugin-tsdoc": "^0.2.17",
-        "eslint-plugin-vue": "latest",
-        "eslint-plugin-vuejs-accessibility": "^2.2.0",
-        "eslint-plugin-vuetify": "^2.0.5",
-        "husky": "^8.0.3",
-        "jsdom": "^22.1.0",
-        "lint-staged": "^14.0.1",
-        "npm-run-all": "^4.1.5",
-        "postcss": "^8.4.20",
-        "postcss-html": "^1.5.0",
-        "postcss-nesting": "^11.2.2",
-        "prettier": "^3.0.3",
-        "rimraf": "^5.0.1",
-        "rollup-plugin-visualizer": "^5.9.2",
-        "sass": "^1.66.1",
-        "stylelint": "^15.10.3",
-        "stylelint-config-recommended-scss": "^12.0.0",
-        "stylelint-config-recommended-vue": "^1.5.0",
-        "stylelint-order": "^6.0.3",
-        "tailwindcss": "^3.2.4",
-        "typescript": "^5.2.0",
-        "vite": "^5.0.10",
-        "vite-plugin-vuetify": "^2.0.1",
-        "vitest": "^0.34.3",
-        "vue-tsc": "^1.8.8"
       }
     }
   }


### PR DESCRIPTION
Bump vuetify to 3.5.x release to benefit from the updated t`VDataPicker` (added range feature) and `VChipGroup` (enhanced small screen UI)