### PR TITLE
feat: `chips` data filter

### DIFF
--- a/browser/src/modules/example/dataFilter/CustomTextFilter.example.vue
+++ b/browser/src/modules/example/dataFilter/CustomTextFilter.example.vue
@@ -1,0 +1,102 @@
+<script setup lang="ts">
+import { useElementHover } from "@vueuse/core";
+import { ref, watch } from "vue";
+
+import DataFilterBase from "@/modules/filter/components/DataFilterBase.vue";
+import useDataFilters, { text } from "@/modules/filter/composables/dataFilter";
+
+const myTable = ref<HTMLTableElement | null>(null);
+const customFilterValue = ref<string>("");
+const tableHovered = useElementHover(myTable);
+
+const { FilterComponent, handles } = useDataFilters({
+  // default display spec
+  // overridable on field-level
+  display: {
+    sm: 6,
+    md: 3,
+  },
+
+  // update style to be borderd
+  sheetProps: {
+    border: true,
+  },
+
+  filter: {
+    table: text({
+      value: customFilterValue,
+      display: {
+        md: 12,
+      },
+      props: {
+        label: "Advanced search",
+        placeholder: "This is a search placeholder",
+      },
+    }),
+  },
+});
+
+watch(tableHovered, (value) =>
+  value ? handles.value?.table.hoverIn() : handles.value?.table.hoverOut(),
+);
+
+function onTableClicked(event: PointerEvent) {
+  if (event.target instanceof HTMLTableCellElement) {
+    customFilterValue.value = event.target.textContent ?? "";
+    // calling this update function is mandatory
+    // this is considered as if the user interaction
+    // updating the value ref is considered programmtic update and does not
+    // trigger enable state changes
+    handles.value?.table.update(event.target.textContent);
+  }
+}
+</script>
+
+<template>
+  <VContainer>
+    <FilterComponent>
+      <template #filter.table="{ baseProps, wrapperClass }">
+        <DataFilterBase v-bind="baseProps" content-border>
+          <VTable
+            ref="myTable"
+            hover
+            :class="[wrapperClass]"
+            @click="onTableClicked"
+          >
+            <thead>
+              <tr>
+                <th>Col1</th>
+                <th>Col2</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>First</td>
+                <td>First</td>
+              </tr>
+              <tr>
+                <td>Second</td>
+                <td>Second</td>
+              </tr>
+            </tbody>
+          </VTable>
+        </DataFilterBase>
+      </template>
+
+      <template #append>
+        Click on any cell of the table to set the filter value to its content
+        <VSpacer />
+
+        <VBtn>Optional append slot used</VBtn>
+      </template>
+    </FilterComponent>
+
+    <VCardText>
+      <VCardItem>
+        Table Text Filter: <strong>{{ customFilterValue }}</strong
+        >. Enabled?:
+        {{ handles?.table.enabled }}
+      </VCardItem>
+    </VCardText>
+  </VContainer>
+</template>

--- a/browser/src/modules/example/dataFilter/DataFilter.example.vue
+++ b/browser/src/modules/example/dataFilter/DataFilter.example.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import { useElementHover } from "@vueuse/core";
-import { ref, watch } from "vue";
+import { ref } from "vue";
 
 import DataFilterBase from "@/modules/filter/components/DataFilterBase.vue";
 import useDataFilters, {
   select,
   text,
+  chips,
+  type ChipsDataFilterItem,
 } from "@/modules/filter/composables/dataFilter";
 
 /* ***
@@ -101,7 +102,7 @@ const { FilterComponent, handles: handles1 } = useDataFilters({
       collapsable: true,
 
       display: {
-        md: 12,
+        md: 6,
       },
     }),
   },
@@ -111,66 +112,48 @@ const { FilterComponent, handles: handles1 } = useDataFilters({
  * Filter Group 2
  * ********* */
 
-const myTable = ref<HTMLTableElement | null>(null);
-const customFilterValue = ref<string>("");
-const tableHovered = useElementHover(myTable);
+const chipValue = ref<string | null>(null);
 
-const { FilterComponent: FilterComponent2, handles } = useDataFilters({
-  // default display spec
-  // overridable on field-level
-  display: {
-    sm: 6,
-    md: 3,
-  },
+const chipOptions: ChipsDataFilterItem<string>[] = [];
 
-  // update style to be borderd
-  sheetProps: {
-    border: true,
-  },
+for (let i = 0; i < 20; i++) {
+  chipOptions.push({
+    value: `id-${i}`,
+    title: "Item NO." + i,
 
+    // per-single chip props
+    chipProps: {
+      color: i === 2 ? "blue" : undefined,
+    },
+  });
+}
+
+const { FilterComponent: FilterComponent2 } = useDataFilters({
   filter: {
-    exx: text({
-      props: {
-        label: "Width percentage example",
-        placeholder: "First name filter example",
-      },
+    chips: chips({
+      value: chipValue,
+      items: chipOptions,
 
-      // override display at filter-level
-      display: {
-        sm: 4,
-        md: 8,
-      },
+      label: "Chips Filter label",
 
-      value: lastName,
+      props: () => ({
+        color: "primary",
+        variant: "tonal",
+      }),
+
+      // generic props passed down to every chip
+      chipProps: () => ({
+        label: true,
+      }),
     }),
 
-    table: text({
-      value: customFilterValue,
-      display: {
-        md: 12,
-      },
-      props: {
-        label: "Advanced search",
-        placeholder: "This is a search placeholder",
-      },
+    texty: text({
+      props: () => ({
+        label: "Vuetify label",
+      }),
     }),
   },
 });
-
-watch(tableHovered, (value) =>
-  value ? handles.value?.table.hoverIn() : handles.value?.table.hoverOut(),
-);
-
-function onTableClicked(event: PointerEvent) {
-  if (event.target instanceof HTMLTableCellElement) {
-    customFilterValue.value = event.target.textContent ?? "";
-    // calling this update function is mandatory
-    // this is considered as if the user interaction
-    // updating the value ref is considered programmtic update and does not
-    // trigger enable state changes
-    handles.value?.table.update(event.target.textContent);
-  }
-}
 </script>
 
 <template>
@@ -206,55 +189,9 @@ function onTableClicked(event: PointerEvent) {
 
     <VDivider class="my-4" />
 
-    <FilterComponent2>
-      <template #filter.table="{ focused, hovered, baseProps, wrapperClass }">
-        <DataFilterBase v-bind="baseProps">
-          <VTable
-            ref="myTable"
-            hover
-            :class="[wrapperClass]"
-            style="border: rgba(var(--v-theme-primary), 0.38) 0.8px solid"
-            :style="{
-              borderWidth: focused.value ? '2px' : '1px',
-              borderColor: hovered.value
-                ? 'rgba(var(--v-theme-primary), 1)'
-                : 'rgba(var(--v-theme-primary), 0.38)',
-            }"
-            @click="onTableClicked"
-          >
-            <thead>
-              <tr>
-                <th>Col1</th>
-                <th>Col2</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>First</td>
-                <td>First</td>
-              </tr>
-              <tr>
-                <td>Second</td>
-                <td>Second</td>
-              </tr>
-            </tbody>
-          </VTable>
-        </DataFilterBase>
-      </template>
-
-      <template #append>
-        Click on any cell of the table to set the filter value to its content
-        <VSpacer />
-
-        <VBtn>Optional append slot used</VBtn>
-      </template>
-    </FilterComponent2>
-
+    <FilterComponent2 />
     <VCardText>
-      <VCardItem>
-        Table Text Filter: {{ customFilterValue }}. Enabled?:
-        {{ handles?.table.enabled }}
-      </VCardItem>
+      <VCardItem> Selected Chip Value: {{ chipValue }}. </VCardItem>
     </VCardText>
   </VContainer>
 </template>

--- a/browser/src/modules/filter/components/DataFilterBase.vue
+++ b/browser/src/modules/filter/components/DataFilterBase.vue
@@ -3,6 +3,7 @@ import { useElementHover } from "@vueuse/core";
 import { computed, ref } from "vue";
 
 const props = defineProps<{
+  label?: string;
   enabled?: boolean;
 
   focused?: boolean;
@@ -32,23 +33,39 @@ const classBinding = computed(() => {
 </script>
 
 <template>
-  <div class="d-flex d-data-filter-base" :class="classBinding">
-    <VSheet
-      width="12"
-      elevation="0"
-      class="d-data-filter-base__toggle h-100 flex-shrink-0 rounded-s"
-      :color="enabled ? 'primary' : undefined"
-      style="cursor: pointer"
-      @click="emit('update:enabled', !enabled)"
-    />
-
-    <div
-      ref="hoverEl"
-      style="max-width: 100%"
-      class="d-data-filter-base__content flex-grow-1"
-      :class="contentBorder ? 'rounded-e' : undefined"
+  <div class="d-flex flex-column d-data-filter-base" :class="classBinding">
+    <slot
+      name="label"
+      :enabled="props.enabled"
+      :focused="focused"
+      :hovered="hovered"
     >
-      <slot />
+      <div
+        v-if="label"
+        class="text-caption mt-1 ms-1 flex-shrink-0 flex-grow-1"
+      >
+        {{ label }}
+      </div>
+    </slot>
+
+    <div class="d-flex">
+      <VSheet
+        width="12"
+        elevation="0"
+        class="d-data-filter-base__toggle flex-shrink-0 rounded-s"
+        :color="enabled ? 'primary' : undefined"
+        style="cursor: pointer"
+        @click="emit('update:enabled', !enabled)"
+      />
+
+      <div
+        ref="hoverEl"
+        style="min-width: 0"
+        class="d-data-filter-base__content flex-grow-1"
+        :class="contentBorder ? 'rounded-e' : undefined"
+      >
+        <slot />
+      </div>
     </div>
   </div>
 </template>

--- a/browser/src/modules/filter/components/DataFilterBase.vue
+++ b/browser/src/modules/filter/components/DataFilterBase.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
 import { useElementHover } from "@vueuse/core";
-import { ref } from "vue";
+import { computed, ref } from "vue";
 
 const props = defineProps<{
   enabled?: boolean;
 
   focused?: boolean;
+
+  contentBorder?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -14,27 +16,38 @@ const emit = defineEmits<{
 
 const hoverEl = ref<HTMLDivElement | null>(null);
 const hovered = useElementHover(hoverEl);
+
+const classBinding = computed(() => {
+  return [
+    {
+      "d-data-filter-base--focused": props.focused,
+      "d-data-filter-base--hovered": hovered.value,
+      "d-data-filter-base--bordered-content": props.contentBorder,
+    },
+    props.enabled
+      ? "d-data-filter-base--enabled"
+      : "d-data-filter-base--disabled",
+  ];
+});
 </script>
 
 <template>
-  <div
-    class="d-flex d-data-filter-base"
-    :class="[
-      focused ? 'd-data-filter-base--focused' : undefined,
-      enabled ? 'd-data-filter-base--enabled' : 'd-data-filter-base--disabled',
-      hovered ? 'd-data-filter-base--hovered' : undefined,
-    ]"
-  >
+  <div class="d-flex d-data-filter-base" :class="classBinding">
     <VSheet
       width="12"
       elevation="0"
-      class="d-data-base-filter__toggle h-100 rounded-s"
+      class="d-data-filter-base__toggle h-100 flex-shrink-0 rounded-s"
       :color="enabled ? 'primary' : undefined"
       style="cursor: pointer"
       @click="emit('update:enabled', !enabled)"
     />
 
-    <div ref="hoverEl" class="flex-grow-1">
+    <div
+      ref="hoverEl"
+      style="max-width: 100%"
+      class="d-data-filter-base__content flex-grow-1"
+      :class="contentBorder ? 'rounded-e' : undefined"
+    >
       <slot />
     </div>
   </div>
@@ -43,20 +56,25 @@ const hovered = useElementHover(hoverEl);
 <style lang="scss">
 @use "vuetify/_settings";
 
-.d-data-base-filter__toggle {
+.d-data-filter-base__toggle {
   cursor: pointer;
 }
-.d-data-filter-base--disabled .d-data-base-filter__toggle {
+.d-data-filter-base--disabled .d-data-filter-base__toggle,
+.d-data-filter-base--bordered-content .d-data-filter-base__content {
   border: rgba(var(--v-theme-primary), 0.38) solid 1px;
 }
 
 // TODO: make use of vuetify's border width and opacity instead of hardcoding
 
-.d-data-filter-base--hovered .d-data-base-filter__toggle {
+.d-data-filter-base--hovered .d-data-filter-base__toggle,
+// eslint-disable-next-line prettier/prettier
+.d-data-filter-base--hovered.d-data-filter-base--bordered-content .d-data-filter-base__content {
   border-color: rgba(var(--v-theme-primary), 1);
 }
 
-.d-data-filter-base--focused .d-data-base-filter__toggle {
+.d-data-filter-base--focused .d-data-filter-base__toggle,
+// eslint-disable-next-line prettier/prettier
+.d-data-filter-base--focused.d-data-filter-base--bordered-content .d-data-filter-base__content {
   border-color: rgba(var(--v-theme-primary), 1);
   border-width: 2px;
 }
@@ -75,11 +93,11 @@ const hovered = useElementHover(hoverEl);
   border-top-right-radius: 0;
 }
 
-.v-locale--is-ltr .d-data-base-filter__toggle {
+.v-locale--is-ltr .d-data-filter-base__toggle {
   border-right-style: none;
 }
 
-.v-locale--is-rtl .d-data-base-filter__toggle {
+.v-locale--is-rtl .d-data-filter-base__toggle {
   border-left-style: none;
 }
 </style>

--- a/browser/src/modules/filter/composables/dataFilter/chipsFilter.ts
+++ b/browser/src/modules/filter/composables/dataFilter/chipsFilter.ts
@@ -1,0 +1,128 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import {
+  ref,
+  defineAsyncComponent,
+  h,
+  mergeProps,
+  type VNode,
+  type MaybeRefOrGetter,
+  toValue,
+} from "vue";
+import { isRef } from "vue";
+
+import type {
+  VChip as VChipType,
+  VChipGroup as VChipGroupType,
+} from "vuetify/components";
+
+import type { DataFilterBase, DataFilterInjection } from "./types";
+import type { Prettify } from "@/utils";
+
+const VChip = defineAsyncComponent(
+  async () => (await import("vuetify/components/VChip")).VChip,
+);
+
+const VChipGroup = defineAsyncComponent(
+  async () => (await import("vuetify/components/VChipGroup")).VChipGroup,
+);
+
+type VChipGroupGenericProps<T = any> = keyof InstanceType<
+  typeof VChipGroupType<T>
+>["$props"];
+
+type InternalChipGroupProps<T> =
+  // Overwrite generic-less props with generic-tied ones
+  // prettier-ignore
+  InstanceType< typeof VChipGroupType<T> >["$props"] 
+  & Omit<InstanceType<typeof VChipGroupType>["$props"], VChipGroupGenericProps<T>>;
+
+type ItemType<T> = T extends readonly (infer U)[]
+  ? NonNullable<U>
+  : NonNullable<T>;
+
+export interface ChipsDataFilterItem<TItemValue> {
+  title?: string;
+  value: TItemValue;
+  /**
+   * Allows passing per-item props to the internal {@link VChip} components
+   */
+  chipProps?: InstanceType<typeof VChipType>["$props"];
+}
+
+export interface ChipsDataFilter<TGroupValue = any> extends DataFilterBase {
+  type: "chips";
+
+  /**
+   * props to be passed down to`VChipGroup`.
+   */
+  props?: MaybeRefOrGetter<InternalChipGroupProps<TGroupValue>>;
+
+  /**
+   * Shared `VChip` props, useful for props that are not available on `VChipGroup`
+   */
+  chipProps?: MaybeRefOrGetter<InstanceType<typeof VChipType>["$props"]>;
+
+  items?: MaybeRefOrGetter<ChipsDataFilterItem<ItemType<TGroupValue>>[]>;
+
+  value?: MaybeRefOrGetter<TGroupValue>;
+
+  contentBorder: true;
+}
+
+type MakeChipsConfig<T> =
+  // omit these keys to be replaced with generic-tied ones
+  Omit<ChipsDataFilter<T>, "type" | "value" | "props" | "contentBorder"> & {
+    props?: MaybeRefOrGetter<InternalChipGroupProps<T>>;
+  } & {
+    value?: MaybeRefOrGetter<T>;
+  };
+
+export function chips<T>(
+  config: Prettify<MakeChipsConfig<T>>,
+): ChipsDataFilter {
+  return {
+    ...config,
+    type: "chips",
+    contentBorder: true,
+  };
+}
+
+export function render(
+  definition: ChipsDataFilter,
+  injection: DataFilterInjection,
+  additionalProps?: Record<string, any>,
+): VNode {
+  const modelProps = {
+    modelValue: toValue(definition.value),
+    "onUpdate:modelValue": (newValue: any) => {
+      if (isRef(definition.value)) {
+        definition.value.value = newValue;
+      }
+      injection.update(newValue);
+    },
+
+    "onUpdate:focused": (value: boolean) => {
+      injection.setFocus(value);
+    },
+  };
+
+  const nodeProps = mergeProps(
+    toValue(definition.props) ?? {},
+    modelProps,
+    additionalProps ?? {},
+  );
+
+  const childChips = toValue(definition.items ?? []).map((itemDef) => {
+    const chipProps = mergeProps(
+      toValue(definition.chipProps) ?? {},
+      itemDef.chipProps ?? {},
+      {
+        value: itemDef.value,
+      },
+    );
+
+    return h(VChip, chipProps, () => itemDef.title ?? itemDef.value);
+  });
+
+  return h(VChipGroup, nodeProps, () => childChips);
+}

--- a/browser/src/modules/filter/composables/dataFilter/chipsFilter.ts
+++ b/browser/src/modules/filter/composables/dataFilter/chipsFilter.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import {
-  ref,
   defineAsyncComponent,
   h,
   mergeProps,
@@ -99,10 +98,6 @@ export function render(
         definition.value.value = newValue;
       }
       injection.update(newValue);
-    },
-
-    "onUpdate:focused": (value: boolean) => {
-      injection.setFocus(value);
     },
   };
 

--- a/browser/src/modules/filter/composables/dataFilter/index.ts
+++ b/browser/src/modules/filter/composables/dataFilter/index.ts
@@ -34,6 +34,8 @@ import {
   type AutocompleteDataFilter,
 } from "./autocompleteFilter";
 export { autocomplete, asyncAutocomplete } from "./autocompleteFilter";
+import { render as renderChips, type ChipsDataFilter } from "./chipsFilter";
+export { chips, type ChipsDataFilterItem } from "./chipsFilter";
 import { render as renderSelect, type SelectDataFilter } from "./selectFilter";
 export { select, asyncSelect } from "./selectFilter";
 import { render as renderText, type TextDataFilter } from "./textFilter";
@@ -56,7 +58,11 @@ import type { Merge } from "@/utils";
  * [ ] chip group (single/many)
  */
 
-type DataFilter = TextDataFilter | SelectDataFilter | AutocompleteDataFilter;
+type DataFilter =
+  | TextDataFilter
+  | SelectDataFilter
+  | AutocompleteDataFilter
+  | ChipsDataFilter;
 
 type Icon = (typeof VIcon)["$props"]["icon"];
 
@@ -258,6 +264,8 @@ export default function useDataFilters<
           filterNode = renderSelect(definition, injection, nodeProps);
         } else if (definition.type === "autocomplete") {
           filterNode = renderAutocomplete(definition, injection, nodeProps);
+        } else if (definition.type === "chips") {
+          filterNode = renderChips(definition, injection, nodeProps);
         }
         // TODO: render other types of filters
 

--- a/browser/src/modules/filter/composables/dataFilter/index.ts
+++ b/browser/src/modules/filter/composables/dataFilter/index.ts
@@ -269,6 +269,8 @@ export default function useDataFilters<
           focused: toValue(injection.focused),
           contentBorder: definition.contentBorder,
 
+          label: toValue(definition.label),
+
           class: [computeDisplayClasses(globalDisplay, definition.display)],
           [`data-filter-name`]: key,
         };
@@ -308,7 +310,11 @@ export default function useDataFilters<
         }
 
         return h(VCardItem, { class: ["flex-row pa-1"] }, () =>
-          h(VRow, { dense: true, class: ["mx-2 my-0 py-1 "] }, () => nodes),
+          h(
+            VRow,
+            { dense: true, class: ["align-end mx-2 my-0 py-1 "] },
+            () => nodes,
+          ),
         );
       }
 
@@ -338,7 +344,10 @@ export default function useDataFilters<
                 VRow,
                 {
                   dense: true,
-                  class: ["mx-2 my-0 py-2", collapsableRowClasses.value],
+                  class: [
+                    "align-end mx-2 my-0 py-2",
+                    collapsableRowClasses.value,
+                  ],
                 },
                 () => nodes,
               ),

--- a/browser/src/modules/filter/composables/dataFilter/index.ts
+++ b/browser/src/modules/filter/composables/dataFilter/index.ts
@@ -267,6 +267,7 @@ export default function useDataFilters<
             injection.setEnabled(newValue);
           },
           focused: toValue(injection.focused),
+          contentBorder: definition.contentBorder,
 
           class: [computeDisplayClasses(globalDisplay, definition.display)],
           [`data-filter-name`]: key,

--- a/browser/src/modules/filter/composables/dataFilter/types.d.ts
+++ b/browser/src/modules/filter/composables/dataFilter/types.d.ts
@@ -12,14 +12,13 @@ export interface DataFilterBase {
    */
   display?: DataFiltersDisplay;
 
-  /**
-   *
-   */
   collapsable?: MaybeRefOrGetter<boolean>;
 
   /**
-   *
+   * Enable if the border around the filter "content" other than the toggle area should be handled internally
    */
+  contentBorder?: boolean;
+
   enabled?: MaybeRefOrGetter<boolean>;
 
   /**

--- a/browser/src/modules/filter/composables/dataFilter/types.d.ts
+++ b/browser/src/modules/filter/composables/dataFilter/types.d.ts
@@ -15,6 +15,11 @@ export interface DataFilterBase {
   collapsable?: MaybeRefOrGetter<boolean>;
 
   /**
+   * Displays a label for filters that do not have a label by design (Chips or toggles)
+   */
+  label?: MaybeRefOrGetter<string>;
+
+  /**
    * Enable if the border around the filter "content" other than the toggle area should be handled internally
    */
   contentBorder?: boolean;


### PR DESCRIPTION
The PR 

### New in this PR
- new `chips` dataFilter
- `DataFilterBase` accepts new props and slots
  - `label` slot/prop 
  - `contentBorder` Previously, only the toggle area's border is managed internally. Now if `contentBorder` is applied the content's border is managed by the component internally. 

The `chips` Filter Shown Below
![image](https://github.com/Esoty-Software-Solutions/dashim/assets/22858957/e3b9acab-7eaf-436e-90c5-9d98db25df36)

### Changes in this PR
-  `DataFilterBase` 
   - Content now properly fits within the content area and never overflows
   - Toggle area will not disappear in favor of the `flex` growing content (flex shrink = 0 )
-  dataFilters delegate `label` and `contentBorder`.
- Update generic styling of data filters to accommodate the addition of a custom label that's displayed outside the filter border